### PR TITLE
Update Calendar uid with a simple check for null

### DIFF
--- a/calendar/lib.php
+++ b/calendar/lib.php
@@ -2851,6 +2851,10 @@ function calendar_add_icalendar_event($event, $unused = null, $subscriptionid, $
     $eventrecord->location = empty($event->properties['LOCATION'][0]->value) ? '' :
             trim(str_replace('\\', '', $event->properties['LOCATION'][0]->value));
     $eventrecord->uuid = $event->properties['UID'][0]->value;
+    if (!isset($eventrecord->uuid)) {
+        $eventrecord->uuid = 1234; //Protects against UUID being 'null' and causing a database write error. not all ical files supply UUID. - Scrat
+    }
+
     $eventrecord->timemodified = time();
 
     // Add the iCal subscription details if required.


### PR DESCRIPTION
The current system for importing an ics file does not check if the ical file contains a valid UID. Most ical inputs from sites like eventbrite and things that can be tied to courses, require that when importing the database write needs a UUID value, which is otherwise null.

This quick 'isset' checks to see if uid is null, and if it is, just puts a quick value in there so the database write passes and the calendar item is added right.

The error is as follows, using the ics file from eventbrite here: https://www.eventbrite.co.uk/e/london-film-comic-con-summer-2019-tickets-49472593860

Error code: dmlwriteexception
* line 489 of /lib/dml/moodle_database.php: dml_write_exception thrown
* line 1329 of /lib/dml/mysqli_native_moodle_database.php: call to moodle_database->query_end()
* line 1375 of /lib/dml/mysqli_native_moodle_database.php: call to mysqli_native_moodle_database->" while reading response header from upstream, client: 10.220.134.242, server: lunamoodle, request: "POST /calendar/managesubscriptions.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php7.3-fpm.sock:", host: "10.220.130.220", referrer: "http://10.220.200.220/calendar/managesubscriptions.php"
2019/07/05 15:50:15 [error] 1419#1419: *2934 FastCGI sent in stderr: "PHP message: PHP Notice:  Undefined index: UID in /var/www/html/moodle/calendar/lib.php on line 2853PHP message: PHP Notice:  Trying to get property 'value' of non-object in /var/www/html/moodle/calendar/lib.php on line 2853PHP message: Default exception handler: Error writing to database Debug: Column 'uuid' cannot be null
INSERT INTO mdl_event (name,description,timestart,timeduration,location,uuid,timemodified,subscriptionid,userid,groupid,courseid,categoryid,eventtype,format) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
[array (
  0 => 'LONDON Film & Comic Con SUMMER 2019',
  1 => 'For details, click here: https://www.eventbrite.co.uk/e/london-film-comic-con-summer-2019-tickets-49472593860',
  2 => 1564131600,
  3 => 205200,
  4 => 'Olympia London -  Hammersmith Rd,  - Hammersmith - W14 8UX  - United Kingdom',
  5 => NULL,
  6 => 1562338215,
  7 => 12,
  8 => '2',
  9 => '0',
  10 => '0',
  11 => '0',
  12 => 'user',
  13 => '1',
)]

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
